### PR TITLE
Display difficulty in skill roll output

### DIFF
--- a/src/commands/rolls/skill.ts
+++ b/src/commands/rolls/skill.ts
@@ -91,7 +91,7 @@ class SkillRollCommand extends Command {
           fields: [
             {
               name: "Successes",
-              value: `${successes}${complicated ? " ⚠️" : ""}`,
+	      value: `${successes}/${options.difficulty} ${complicated ? " ⚠️" : ""}`,
               inline: true,
             },
             {
@@ -179,7 +179,7 @@ class SkillRollCommand extends Command {
         .slice(1)
         .find((arg) => /^-?[\d.]+(?:e-?\d+)?$/.test(arg));
       const difficulty =
-        (difficultyString && parseInt(difficultyString)) || undefined;
+        (difficultyString && parseInt(difficultyString)) || 0;
 
       let dice: number | undefined;
       let tag: number | undefined;


### PR DESCRIPTION
Shows the difficulty of the roll as part of the 'Sucessess'
output on the skill roll, so it is clear what difficulty you were
rolling against.

Also I changed the default for difficulty to be 0 if it is omitted
on the command line, if this should not be possible then the command
parsing should be checked over.